### PR TITLE
Replace akmer100b references with akmer102

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ The external software that we use (e.g., tools not found in conda, like our vers
 | **metabat2**   | Bins assembled contigs into putative MAGs based on coverage and sequence composition.                        |
 | **fac**        | Filters contigs based on length and coverage.                                                                |
 | **lingenome**  | Generates concatenated genomes from individual FASTA files.                                                  |
-| **akmer100b**  | Calculates k-mer frequencies and distances for genome comparisons.                                           |
+| **akmer102**  | Calculates k-mer frequencies and distances for genome comparisons.                                           |
 | **bestmag2** | Selects the "best" MAGs based on quality metrics and coverage information.                          |
 | **spamw2**     | Clusters genomes based on pairwise jaccard distances.                                                        |
 

--- a/magus/cluster-contigs.py
+++ b/magus/cluster-contigs.py
@@ -91,17 +91,17 @@ class ContigClustering:
 		print(f"Running lingenome to generate combined contigs file: {self.combined_output}")
 		subprocess.run(cmd, shell=True)
 
-	def run_akmer100b(self):
-		# Run akmer100b to generate the distance matrix
-		distance_matrix = f"{self.combined_output.replace('.fasta', '')}.dm"
-		cmd_akmer = f"OMP_NUM_THREADS={self.threads} akmer102 {self.combined_output} {distance_matrix} 16 ANI CHANCE GC LOCAL RC"
-		print(f"Running akmer102 to generate distance matrix: {distance_matrix}")
-		subprocess.run(cmd_akmer, shell=True)
-		return distance_matrix
+        def run_akmer102(self):
+                # Run akmer102 to generate the distance matrix
+                distance_matrix = f"{self.combined_output.replace('.fasta', '')}.dm"
+                cmd_akmer = f"OMP_NUM_THREADS={self.threads} akmer102 {self.combined_output} {distance_matrix} 16 ANI CHANCE GC LOCAL RC"
+                print(f"Running akmer102 to generate distance matrix: {distance_matrix}")
+                subprocess.run(cmd_akmer, shell=True)
+                return distance_matrix
 
 	def run_clustering(self):
-		# Run spamw2 for clustering and bestmag for selecting best bins
-		distance_matrix = self.run_akmer100b()  # Generate the distance matrix
+                # Run spamw2 for clustering and bestmag for selecting best bins
+                distance_matrix = self.run_akmer102()  # Generate the distance matrix
 		cluster_output = f"{self.tmp_dir}/clus/S"
 		coasm_output = f"{self.tmp_dir}/coasm.reps"
 		

--- a/magus/coassembly-binning.py
+++ b/magus/coassembly-binning.py
@@ -90,8 +90,8 @@ class CoAssemblyBinning:
         print(f"Running lingenome for {BS}")
         subprocess.run(f"lingenome {OUTF}/good {OUTF}/good.fasta FILENAME", shell=True)
 
-        print(f"Running akmer100b for {BS}")
-        subprocess.run(f"OMP_NUM_THREADS={self.threads} akmer100b {OUTF}/good.fasta {OUTF}/good.dm 13 ANI CHANCE GC LOCAL RC", shell=True)
+        print(f"Running akmer102 for {BS}")
+        subprocess.run(f"OMP_NUM_THREADS={self.threads} akmer102 {OUTF}/good.fasta {OUTF}/good.dm 13 ANI CHANCE GC LOCAL RC", shell=True)
 
         print(f"Running spamw for {BS}")
         subprocess.run(f"spamw2 {OUTF}/good.dm {OUTF}/L 0 {self.threads} D2", shell=True)

--- a/magus/single-binning.py
+++ b/magus/single-binning.py
@@ -133,7 +133,7 @@ class Binning:
         print(f"Running lingenome for {sample_name}")
         subprocess.run(cmd, shell=True)
 
-    def run_akmer100b(self, sample_name):
+    def run_akmer102(self, sample_name):
         parent_dir = f"{self.tmpdir}/{sample_name}"
         good_fasta = f"{parent_dir}/good.fasta"
         good_dm = f"{parent_dir}/good.dm"
@@ -189,7 +189,7 @@ class Binning:
             self.filter_good_bins(sample_name)
             self.copy_good_bins(sample_name)
             self.run_lingenome(sample_name)
-            self.run_akmer100b(sample_name)
+            self.run_akmer102(sample_name)
             self.run_spamw(sample_name)
             self.run_bestmag(sample_name)
             self.run_final_copy(sample_name)


### PR DESCRIPTION
## Summary
- update binary name in documentation
- rename `run_akmer100b` methods to `run_akmer102`
- update code to call `akmer102`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'magus')*

------
https://chatgpt.com/codex/tasks/task_e_684088ef87e8832e9bcf8ebe78046038