### PR TITLE
Add quality threshold options to single-binning

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ In the near future we'll release our gene catalog modules that enable functional
 |                          | `--max_workers`           | Number of parallel jobs to run simultaneously                  |
 |                          | `--tmp_dir`               | Temporary directory for intermediate files                     |
 |                          | `--test_mode`             | Enables test mode for debugging                                |
+|                          | `--completeness`          | Custom completeness threshold for bins                         |
+|                          | `--contamination`         | Custom contamination threshold for bins                        |
+|                          | `--low-quality`           | Include bins of low quality or better (not recommended)        |
+|                          | `--medium-quality`        | Include bins of medium quality or better                       |
+|                          | `--high-quality`          | Include only high quality bins                                 |
 | **cluster-contigs**      | `--config`                | Location of the configuration file containing the qc'd reads                              |
 |                          | `--threads`               | Number of threads assigned per job                             |
 |                          | `--contig_dir`            | Directory containing contigs for clustering                    |

--- a/magus/single-binning.py
+++ b/magus/single-binning.py
@@ -6,7 +6,8 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import shutil
 
 class Binning:
-    def __init__(self, config,tmp_dir, asmdir, magdir="mags", threads=14, checkm_db=None, test_mode=False, max_workers=4,skipcm = False):
+    def __init__(self, config,tmp_dir, asmdir, magdir="mags", threads=14, checkm_db=None, test_mode=False, max_workers=4,skipcm = False,
+                 completeness=None, contamination=None, quality=None):
         self.config = self.load_config(config)
         self.asmdir = asmdir
         self.magdir = asmdir+"/"+magdir
@@ -16,6 +17,9 @@ class Binning:
         self.test_mode = test_mode  # Flag for test mode
         self.max_workers = max_workers  # Maximum parallel workers
         self.skip_checkm = skipcm
+        self.completeness = completeness
+        self.contamination = contamination
+        self.quality = quality
 
         # Create the output directories if they don't exist
         os.makedirs(f"{self.magdir}", exist_ok=True)
@@ -91,12 +95,28 @@ class Binning:
         checkm_report = f"{out_sample_dir}/bins/checkm/quality_report.tsv"
         worthwhile_bins = f"{out_sample_dir}/worthwhile.tsv"
         
-        if self.test_mode:
+        # Determine filtering thresholds
+        if self.quality == 'low':
             completeness_cutoff = 0
             contamination_cutoff = 100
+        elif self.quality == 'medium':
+            completeness_cutoff = 50
+            contamination_cutoff = 10
+        elif self.quality == 'high':
+            completeness_cutoff = 90
+            contamination_cutoff = 5
         else:
             completeness_cutoff = 50
             contamination_cutoff = 5
+
+        if self.completeness is not None:
+            completeness_cutoff = self.completeness
+        if self.contamination is not None:
+            contamination_cutoff = self.contamination
+
+        if self.test_mode:
+            completeness_cutoff = 0
+            contamination_cutoff = 100
 
         cmd = f"awk -F'\\t' '$2 >= {completeness_cutoff} && $3 <= {contamination_cutoff}' {checkm_report} > {worthwhile_bins}"
         subprocess.run(cmd, shell=True)
@@ -220,11 +240,25 @@ def main():
     parser.add_argument('--tmp_dir', type=str, default='tmp/single-binning', help='Temp directory. Default tmp/single-binning.')
     parser.add_argument('--test_mode', action='store_true', help='Enable test mode with relaxed filtering criteria')
     parser.add_argument('--skipcheckm',action = 'store_true', help='Skips checkm and downstream steps (so stops immediately after binning)')
+    parser.add_argument('--completeness', type=float, default=None, help='Completeness threshold for filtering bins')
+    parser.add_argument('--contamination', type=float, default=None, help='Contamination threshold for filtering bins')
+    quality_group = parser.add_mutually_exclusive_group()
+    quality_group.add_argument('--low-quality', dest='low_quality', action='store_true', help='Allow low quality bins (not recommended)')
+    quality_group.add_argument('--medium-quality', dest='medium_quality', action='store_true', help='Use medium quality thresholds (completeness >=50, contamination <=10)')
+    quality_group.add_argument('--high-quality', dest='high_quality', action='store_true', help='Use high quality thresholds (completeness >=90, contamination <=5)')
 
     # Parse arguments
     args = parser.parse_args()
 
     # Initialize and run the Binning instance
+    quality = None
+    if args.low_quality:
+        quality = 'low'
+    elif args.medium_quality:
+        quality = 'medium'
+    elif args.high_quality:
+        quality = 'high'
+
     binning = Binning(
         config=args.config,
         threads=args.threads,
@@ -233,7 +267,10 @@ def main():
         tmp_dir=args.tmp_dir,
         max_workers=args.max_workers,
         test_mode=args.test_mode,
-        skipcm=args.skipcheckm
+        skipcm=args.skipcheckm,
+        completeness=args.completeness,
+        contamination=args.contamination,
+        quality=quality
     )
     binning.run()
 


### PR DESCRIPTION
## Summary
- allow custom completeness/contamination thresholds
- add quality presets (low/medium/high)
- document the new options in `README`

## Testing
- `bash scripts/run_all_tests.sh` *(fails: pandas not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684088c3078c832e8f036a9b222f48d0