### PR TITLE
Fix paired-end path in subsample_reads

### DIFF
--- a/magus/subsample-reads.py
+++ b/magus/subsample-reads.py
@@ -52,8 +52,8 @@ class ReadSubsampler:
             subprocess.run(cmd1, shell=True, check=True)
 
             if pe2.strip():  # If pe2 is NOT empty, process it as paired-end
-                pe2_subsampled = os.path.join(self.outdir, f"{filename}_2.{file_extension}")
-                cmd2 = f"{self.seqtk_path} sample -s100 {pe2} {self.depth} | gzip > {pe2_subsampled}.gz"
+                pe2_subsampled = os.path.join(self.outdir, f"{filename}_2.{file_extension}.gz")
+                cmd2 = f"{self.seqtk_path} sample -s100 {pe2} {self.depth} | gzip > {pe2_subsampled}"
                 subprocess.run(cmd2, shell=True, check=True)
                 return filename, pe1_subsampled, pe2_subsampled
             return filename, pe1_subsampled, ""  # If single-end, return empty pe2

--- a/tests/test_subsample_reads.py
+++ b/tests/test_subsample_reads.py
@@ -1,0 +1,39 @@
+import unittest
+from unittest.mock import patch
+import tempfile
+import os
+import pandas as pd
+
+# Import the module using importlib since the file name contains a hyphen
+import importlib.util
+module_path = os.path.join(os.path.dirname(__file__), '..', 'magus', 'subsample-reads.py')
+spec = importlib.util.spec_from_file_location('subsample_reads', module_path)
+subsample_reads = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(subsample_reads)
+
+class TestSubsampleReads(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        config_path = os.path.join(self.temp_dir.name, 'config.tsv')
+        df = pd.DataFrame([
+            ['sample1', 'read1.fq.gz', 'read2.fq.gz']
+        ], columns=['filename', 'pe1', 'pe2'])
+        df.to_csv(config_path, sep='\t', index=False)
+        out_config = os.path.join(self.temp_dir.name, 'out_config.tsv')
+        self.subsampler = subsample_reads.ReadSubsampler(
+            config=config_path,
+            outdir=self.temp_dir.name,
+            out_config=out_config,
+            depth=10
+        )
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    @patch('subprocess.run')
+    def test_paired_end_output_has_gz(self, mock_run):
+        _, _, pe2_out = self.subsampler.subsample_reads('sample1', 'read1.fq.gz', 'read2.fq.gz')
+        self.assertTrue(pe2_out.endswith('.gz'))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix gz path handling in subsample-reads
- add regression test for ReadSubsampler

## Testing
- `pytest -q` *(fails: cannot import modules and missing pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68408769d67c832ebb6cacb7cd8a2e93