### PR TITLE
Document CLI updates and normalize tmpdir flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,86 +72,144 @@ This is a **wildly** memory intensive piece of software. It is not meant to be r
 
 ## Commands and arguments
 
-The sequence of commands to run the full pipeline is as follows:
+MAGUS exposes the following sub-commands through `magus <command>`:
 
-| Command       | Description                                                                                                  |
-|----------------|--------------------------------------------------------------------------------------------------------------|
-| magus qc |   Read quality control and compression    |
-| magus single-assembly |    Assemble samples one at a time        |
-| magus single-binning |  Bin genomes with MetaBAT2  and run CheckM2  |
-| magus cluster-contigs |   Identify samples for potential co-assembly  |
-| magus coassembly |  Co-assemble samples|
-| magus coassembly-binning |    Run MetaBAT2 and CheckM2 on coassembled bins    |
-| magus finalize-bacterial-mags |  Filter redundant bacterial/archaeal MAGS identified in both single and coassembly binning.  |
-| magus find-viruses | Identify viral contigs with CheckV |
-| magus find-euks | Identify putative eukaryotic bins with EukRep and EukCC   |
+| Command | Description |
+| --- | --- |
+| `magus qc` | Run read QC and compression with `shi7_trimmer` and `minigzip`. |
+| `magus assemble-hosts` | Generate host assemblies and clustering metadata used to mask dominant genomes prior to metagenomic processing. |
+| `magus subsample-reads` | Down-sample reads with `seqtk` and emit an updated config file. |
+| `magus filter-reads` | Remove reads matching host references using xtree `.perq` output. |
+| `magus taxonomy` | Run xtree on raw reads to generate coverage, taxonomy, and abundance summaries. |
+| `magus single-assembly` | Assemble each sample independently with MEGAHIT. |
+| `magus binning` | Bin single-assembly contigs with MetaBAT2 and assess quality with CheckM2. |
+| `magus cluster-contigs` | Collect filtered contigs, perform clustering, and build the co-assembly task list. |
+| `magus coassembly` | Execute co-assemblies for grouped samples. |
+| `magus coassembly-binning` | Bin co-assembly results and evaluate bins with CheckM2. |
+| `magus finalize-bacterial-mags` | Merge redundant bacterial/archaeal MAGs across single and co-assemblies. |
+| `magus find-viruses` | Merge contigs, run CheckV, and dereplicate viral genomes. |
+| `magus find-euks` | Identify putative eukaryotic genomes using EukRep and EukCC. |
+| `magus dereplicate` | Dereplicate MAGs with lingenome and canolax5. |
+| `magus call-orfs` | Call and annotate open reading frames across MAG collections. |
+| `magus build-gene-catalog` | Build pan-genome gene catalogs from ORF predictions. |
+| `magus filter-mags` | Filter MAGs using xtree alignment statistics. |
+| `magus build-tree` | Construct phylogenetic trees from concatenated single-copy genes. |
 
-In the near future we'll release our gene catalog modules that enable functional comparison of various genomes and construction of phylogenetic trees.
+### Command arguments
 
-## Command arguments
+Key options for each command are summarised below (see `magus <command> --help` for complete details):
 
-| Command                  | Argument                   | Description                                                    |
-|--------------------------|----------------------------|----------------------------------------------------------------|
-| **qc**      | `--config`                | Location of the configuration file containing the raw reads                            |
-|                          | `--max_workers`           | Number of parallel jobs to run simultaneously                  |
-|                          | `--threads`               | Number of threads assigned per job                             |
-| **single-assembly**      | `--config`                | Location of the configuration file containing the qc'd reads                            |
-|                          | `--max_workers`           | Number of parallel jobs to run simultaneously                  |
-|                          | `--threads`               | Number of threads assigned per job                             |
-| **single-binning**       | `--config`                | Location of the configuration file containing the qc'd reads                             |
-|                          | `--threads`               | Number of threads assigned per job                             |
-|                          | `--asmdir`                | Directory for the assembly output                              |
-|                          | `--max_workers`           | Number of parallel jobs to run simultaneously                  |
-|                          | `--tmp_dir`               | Temporary directory for intermediate files                     |
-|                          | `--test_mode`             | Enables test mode for debugging                                |
-|                          | `--completeness`          | Custom completeness threshold for bins                         |
-|                          | `--contamination`         | Custom contamination threshold for bins                        |
-|                          | `--low-quality`           | Include bins of low quality or better (not recommended)        |
-|                          | `--medium-quality`        | Include bins of medium quality or better                       |
-|                          | `--high-quality`          | Include only high quality bins                                 |
-| **cluster-contigs**      | `--config`                | Location of the configuration file containing the qc'd reads                              |
-|                          | `--threads`               | Number of threads assigned per job                             |
-|                          | `--contig_dir`            | Directory containing contigs for clustering                    |
-|                          | `--combined_output`       | File to store combined contig output                           |
-|                          | `--tmp_dir`               | Temporary directory for intermediate files                     |
-| **coassembly**           | `--config`                | Location of the configuration file containing the qc'd reads                              |
-|                          | `--coasm_todo`            | To-do list or specification file for co-assembly tasks         |
-|                          | `--outdir`                | Output directory for co-assembly results                       |
-|                          | `--tmp_dir`               | Temporary directory for intermediate files                     |
-|                          | `--threads`               | Number of threads assigned per job                             |
-|                          | `--test_mode`             | Enables test mode for debugging                                |
-| **coassembly-binning**   | `--config`                | Location of the configuration file containing the qc'd reads                              |
-|                          | `--coasm_outdir`          | Directory to store co-assembly output                          |
-|                          | `--tmp_dir`               | Temporary directory for intermediate files                     |
-|                          | `--threads`               | Number of threads assigned per job                             |
-|                          | `--checkm_db`             | Path to CheckM database for quality assessment                 |
-|                          | `--max_workers`           | Number of parallel jobs to run simultaneously                  |
-|                          | `--test_mode`             | Enables test mode for debugging                                |
-| **find-viruses**         | `--asm_dir`               | Directory for single-assembly files                            |
-|                          | `--coasm_dir`             | Directory for co-assembly files                                |
-|                          | `--combined_contig_file`  | File containing combined contigs for analysis                  |
-|                          | `--filtered_contig_file`  | File containing filtered contigs based on length and quality   |
-|                          | `--min_length`            | Minimum length cutoff for viral contigs                        |
-|                          | `--max_length`            | Maximum length cutoff for viral contigs                        |
-|                          | `--threads`               | Number of threads assigned per job                             |
-|                          | `--quality`               | Quality threshold for viral identification                     |
-|                          | `--tmp_dir`               | Temporary directory for intermediate files                     |
-|                          | `--dblocs`                | Database locations for viral identification                    |
-| **find-euks**            | `--coasm_dir`             | Directory for co-assembly files                                |
-|                          | `--asm_dir`               | Directory for single-assembly files                            |
-|                          | `--size_threshold`        | Size threshold for eukaryotic genome detection                 |
-|                          | `--euk_binning_outputdir` | Output directory for eukaryotic binning results                |
-|                          | `--dblocs`                | Database locations for eukaryotic genome identification        |
-|                          | `--max_workers`           | Number of parallel jobs to run simultaneously                  |
-|                          | `--threads`               | Number of threads assigned per job                             |
-|                          | `--skip_eukrep`           | Option to skip EukRep-based filtering                          |
-|                          | `--eukrep_env`            | Conda environment for running EukRep                           |
-|                          | `--skip_eukcc`            | Option to skip EukCC-based filtering                           |
-| **finalize-bacterial-mags** | `--singleassembly_mag_dir` | Directory for single-assembly MAGs                          |
-|                          | `--coasm_mag_dir`         | Directory for co-assembly MAGs                                 |
-|                          | `--outdir`                | Output directory for finalized bacterial MAGs                  |
-|                          | `--threads`               | Number of threads assigned per job                             |
-|                          | `--tmp_dir`               | Temporary directory for intermediate files                     |
+- **qc** (`magus qc`)
+  - `--config`: TSV describing raw reads.
+  - `--slurm_config`: Optional Slurm settings for batch execution.
+  - `--max_workers`: Parallel samples to process at once.
+  - `--mode`: `local` or `slurm` execution mode.
+- **assemble-hosts** (`magus assemble-hosts`)
+  - `--config`: TSV of reads to subsample for host assembly.
+  - `--threads` / `--max_workers`: Compute resources for preprocessing.
+  - `--ksize`: Override the number of host clusters to recover.
+  - `--output_config`: Destination for the host-filtering config.
+  - `--tmpdir`: Working directory for intermediate host files.
+- **subsample-reads** (`magus subsample-reads`)
+  - `--config`: Input sequencing config.
+  - `--outdir`: Directory for subsampled reads.
+  - `--out_config`: Path for the updated config file.
+  - `--depth`: Target read count per sample.
+  - `--threads` / `--max_workers`: Parallelism controls.
+- **filter-reads** (`magus filter-reads`)
+  - `--config`: Sequencing config aligning filenames to read pairs.
+  - `--perq_dir`: Directory containing xtree `.perq` files.
+  - `--output_dir`: Where filtered reads are written.
+  - `--min_kmers`: Minimum k-mer evidence retained per read.
+  - `--threads` / `--max_workers`: Filtering parallelism.
+- **taxonomy** (`magus taxonomy`)
+  - `--config`: TSV mapping sample IDs to read locations.
+  - `--db`: xtree database to query.
+  - `--output`: Output directory for alignments and summaries.
+  - `--threads` / `--max_workers`: Worker and thread counts.
+  - `--coverage-cutoff` and `--skip-*` flags: Control downstream filtering and optional output files.
+- **single-assembly** (`magus single-assembly`)
+  - `--config`: QC'd read configuration.
+  - `--threads`: Threads passed to MEGAHIT.
+  - `--max_workers`: Number of samples assembled in parallel.
+  - `--mode` / `--slurm_config`: Toggle and configure Slurm execution.
+- **binning** (`magus binning`)
+  - `--config`: Assembly config file (expects `filename`, `pe1`, `pe2`).
+  - `--asmdir`: Location of assemblies to bin.
+  - `--tmpdir`: Scratch directory for binning intermediates.
+  - `--threads` / `--max_workers`: Resources for MetaBAT2 and CheckM2.
+  - `--checkm_db`: Optional CheckM database override.
+  - Quality thresholds (`--completeness`, `--contamination`, `--low-quality`, `--medium-quality`, `--high-quality`) and `--restart` flags to resume stages.
+- **cluster-contigs** (`magus cluster-contigs`)
+  - `--config`: Same config used for single assemblies.
+  - `--asmdir` / `--magdir`: Source assemblies and MAGs.
+  - `--contig_dir` / `--combined_output`: Output paths for filtered contigs.
+  - `--threads`: CPU threads for clustering utilities.
+  - `--tmpdir`: Workspace for clustering output.
+- **coassembly** (`magus coassembly`)
+  - `--config`: Sequencing config.
+  - `--coasm_todo`: Task list generated by `cluster-contigs`.
+  - `--outdir`: Destination for co-assembly results.
+  - `--tmpdir`: Working directory for co-assembly intermediates.
+  - `--threads`: Threads allocated per co-assembly.
+  - `--test_mode`: Relax filters and generate smaller test runs.
+- **coassembly-binning** (`magus coassembly-binning`)
+  - `--config`: Sequencing config.
+  - `--coasm_outdir`: Root of co-assembly outputs to process.
+  - `--tmpdir`: Scratch directory for binning.
+  - `--threads` / `--max_workers`: Resource controls.
+  - `--checkm_db`: Optional CheckM database override.
+  - `--test_mode` and `--restart`: Control relaxed thresholds and resume behaviour.
+- **finalize-bacterial-mags** (`magus finalize-bacterial-mags`)
+  - `--singleassembly_mag_dir` / `--coasm_mag_dir`: Input MAG locations.
+  - `--outdir`: Final MAG export directory.
+  - `--threads`: CPU threads for dereplication.
+  - `--tmpdir`: Temporary directory for merging work.
+- **find-viruses** (`magus find-viruses`)
+  - `--asm_paths` *or* `--config`: Supply assemblies to scan.
+  - `--checkv_db`: CheckV database location.
+  - `--combined_contig_file` / `--filtered_contig_file`: Filenames for merged contigs.
+  - `--quality`: CheckV quality tiers to retain.
+  - `--tmpdir`: Scratch directory for CheckV runs and dereplication.
+  - `--restart cleanup`: Resume downstream processing after CheckV completes.
+- **find-euks** (`magus find-euks`)
+  - `--bin_dirs`: Pipe-delimited directories to search for bins.
+  - `--wildcards`: Patterns (also pipe-delimited) to match candidate bins.
+  - `--size_threshold`: Minimum bin size included (bp).
+  - `--euk_binning_outputdir`: Output directory for eukaryotic bins.
+  - `--dblocs`: Mapping file for database paths (expects `eukccdb`).
+  - `--max_workers` / `--threads`: Concurrency settings.
+  - `--skip_eukrep`, `--skip_eukcc`, `--eukrep_env`, `--checkm2_file`: Control filtering stages.
+- **dereplicate** (`magus dereplicate`)
+  - `--mag_dir`: Glob pointing to MAGs to dereplicate.
+  - `--tmpdir`: Working directory for lingenome and canolax intermediates.
+  - `--threads`: Threads for canolax5.
+  - `--extension`, `--wildcard`, `--output`, `--kmer_size`, `--max_genome_size`: Options controlling dereplication scope and behaviour.
+- **call-orfs** (`magus call-orfs`)
+  - Supports configs or globs via `--config` or `--mag_dir`/`--wildcard`.
+  - Control domains, annotation targets, and runtime via `--domain`, `--output_directory`, `--max_workers`, `--threads`, `--extension`, and `--force`.
+  - Annotation flags include `--hmmfile`, `--annotation-fullseq-evalue`, `--annotation-domain-evalue`, `--suffix`, `--eukdb`, `--cleanup`, and `--restart`.
+- **build-gene-catalog** (`magus build-gene-catalog`)
+  - `--summary-file`: ORF summary table.
+  - `--faa-dir`: Directory of amino-acid FASTA files.
+  - `--output-dir`: Catalog output root.
+  - `--threads`: Threads for MMseqs2.
+  - Filtering knobs: `--evalue-cutoff`, `--identity-threshold`, `--coverage-threshold`, `--identity-only`, `--multi-sample-single-copy`.
+  - `--tmpdir`: Working directory handed to MMseqs2.
+- **filter-mags** (`magus filter-mags`)
+  - `--output-dir`: Filtered MAG destination.
+  - `--perq-dir`: Directory housing xtree `.perq` files.
+  - `--mag-dir`: MAG directory to filter.
+  - `--kmer-threshold`: Evidence cutoff for retaining contigs.
+- **build-tree** (`magus build-tree`)
+  - Positional `fasta_dir`: Directory of per-genome alignments.
+  - `--gene-list`: Single-copy gene definitions.
+  - `--orf-data`: ORF summary file.
+  - `--coverage-threshold`, `--evalue-cutoff`, `--trimal-cutoff`: Filtering parameters for alignments.
+  - `--iqtree`: Toggle IQ-TREE instead of FastTree.
+  - `--output-dir`: Output directory for trees.
+  - `--genome-list`: Optional list of genomes to include.
+  - `--threads`: Parallelism for tree building.
 
 ## Conda and python dependencies 
 

--- a/magus/build_gene_catalog.py
+++ b/magus/build_gene_catalog.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 class GeneCatalogBuilder:
     def __init__(self, summary_file, faa_dir, output_dir, threads=1, 
                  evalue_cutoff=0.01, identity_threshold=0.3, coverage_threshold=0.8,
-                 identity_only=False, multi_sample_single_copy=False, tmp_dir='./tmp/'):
+                 identity_only=False, multi_sample_single_copy=False, tmpdir='./tmp/'):
         self.summary_file = Path(summary_file) if summary_file else None
         self.faa_dir = Path(faa_dir)
         self.output_dir = Path(output_dir)
@@ -35,7 +35,7 @@ class GeneCatalogBuilder:
         self.coverage_threshold = coverage_threshold
         self.identity_only = identity_only
         self.multi_sample_single_copy = multi_sample_single_copy
-        self.tmp_dir = Path(tmp_dir)
+        self.tmp_dir = Path(tmpdir)
         
         # Create output directory
         self.output_dir.mkdir(parents=True, exist_ok=True)
@@ -513,7 +513,7 @@ def main():
     )
     
     parser.add_argument(
-        '--tmp-dir',
+        '--tmpdir',
         default='./tmp/',
         help='Temporary directory for MMseqs2 (default: ./tmp/)'
     )
@@ -535,7 +535,7 @@ def main():
         coverage_threshold=args.coverage_threshold,
         identity_only=args.identity_only,
         multi_sample_single_copy=args.multi_sample_single_copy,
-        tmp_dir=args.tmp_dir
+        tmpdir=args.tmpdir
     )
     
     try:

--- a/magus/cluster-contigs.py
+++ b/magus/cluster-contigs.py
@@ -4,10 +4,10 @@ import argparse
 import pandas as pd
 
 class ContigClustering:
-	def __init__(self, config, asmdir, magdir,tmp_dir,contig_dir="contigs", combined_output="Contigs.fasta", threads=28):
+	def __init__(self, config, asmdir, magdir,tmpdir,contig_dir="contigs", combined_output="Contigs.fasta", threads=28):
 		self.config = self.load_config(config)
 		self.threads = threads
-		self.tmp_dir = tmp_dir
+		self.tmp_dir = tmpdir
 		self.asmdir = asmdir
 		self.magdir = magdir
 		self.contig_dir = self.tmp_dir + '/' + contig_dir
@@ -136,7 +136,7 @@ def main():
 	parser.add_argument('--combined_output', type=str, default="Contigs.fasta", help='Output file for combined contigs (default: Contigs.fasta)')
 	parser.add_argument('--asmdir', type=str, default='asm/', help='Directory with assemblies. Default is ./asm')
 	parser.add_argument('--magdir', type=str, default='asm/mags/', help='Directory with single assembled MAGs. Default is ./asm/mags')
-	parser.add_argument('--tmp_dir', type=str, default='tmp/cluster-contigs', help='Temp directory. Default tmp/cluster-contigs.')
+	parser.add_argument('--tmpdir', type=str, default='tmp/cluster-contigs', help='Temp directory. Default tmp/cluster-contigs.')
 
 	# Parse arguments
 	args = parser.parse_args()
@@ -149,7 +149,7 @@ def main():
 		magdir = args.magdir,
 		combined_output=args.combined_output,
 		threads=args.threads,
-		tmp_dir=args.tmp_dir
+		tmpdir=args.tmpdir
 	)
 	clustering.run()
 

--- a/magus/coassembly-binning.py
+++ b/magus/coassembly-binning.py
@@ -155,7 +155,7 @@ def main():
     parser = argparse.ArgumentParser(description="Run co-assembly and binning pipeline.")
     parser.add_argument('--config', type=str, required=True, help='Path to the configuration TSV file')
     parser.add_argument('--coasm_outdir', type=str, default="coasm", help='Output directory from previous step (default: coasm)')
-    parser.add_argument('--tmp_dir', default = 'tmp/coassembly-binning',type=str, help='Temporary directory (default: tmp/coassembly-binning)')
+    parser.add_argument('--tmpdir', default = 'tmp/coassembly-binning',type=str, help='Temporary directory (default: tmp/coassembly-binning)')
     parser.add_argument('--threads', type=int, default=28, help='Number of threads (default: 48)')
     parser.add_argument('--checkm_db', type=str, help='Path to a custom CheckM database')
     parser.add_argument('--max_workers', type=int, default=4, help='Maximum number of parallel workers (default: 4)')
@@ -168,7 +168,7 @@ def main():
     binning = CoAssemblyBinning(
         config=args.config,
         outdir=args.coasm_outdir,
-        tmpdir=args.tmp_dir,
+        tmpdir=args.tmpdir,
         threads=args.threads,
         checkm_db=args.checkm_db,
         max_workers=args.max_workers,

--- a/magus/coassembly.py
+++ b/magus/coassembly.py
@@ -161,7 +161,7 @@ def main():
     parser.add_argument('--config', type=str, required=True, help='Path to the configuration TSV file')
     parser.add_argument('--coasm_todo', type=str, required=True, help='Path to output of cluster_contigs, the coasm_todo file')
     parser.add_argument('--outdir', type=str, default="coasm", help='Output directory for co-assembly (default: coasm)')
-    parser.add_argument('--tmp_dir', type=str,default = 'tmp/coasm', help='Temporary directory (default: ~/partmp)')
+    parser.add_argument('--tmpdir', type=str,default = 'tmp/coasm', help='Temporary directory (default: ~/partmp)')
     parser.add_argument('--threads', type=int, default=48, help='Number of threads for tools (default: 48)')
     parser.add_argument('--test_mode', action='store_true', help='Enable test mode with relaxed filtering criteria')
 
@@ -170,7 +170,7 @@ def main():
     coassembly = CoAssembly(
         config=args.config,
         outdir=args.outdir,
-        tmpdir=args.tmp_dir,
+        tmpdir=args.tmpdir,
         coasm_todo=args.coasm_todo,
         threads=args.threads,
         test_mode=args.test_mode

--- a/magus/dereplicate-genomes.py
+++ b/magus/dereplicate-genomes.py
@@ -8,9 +8,9 @@ from pathlib import Path
 import glob
 
 class Dereplicator:
-	def __init__(self, mag_glob, tmp, threads, extension, wildcard, output, kmer_size, max_genome_size):
+	def __init__(self, mag_glob, tmpdir, threads, extension, wildcard, output, kmer_size, max_genome_size):
 		self.input_paths = [Path(p).resolve() for p in glob.glob(mag_glob, recursive=True)]
-		self.tmp = Path(tmp)
+		self.tmp = Path(tmpdir)
 		self.threads = threads
 		self.extension = extension
 		self.wildcard = wildcard
@@ -189,7 +189,7 @@ class Dereplicator:
 def main():
 	parser = argparse.ArgumentParser(description="Dereplicate MAGs using lingenome and canolax5.")
 	parser.add_argument("-m", "--mag_dir", type=str, required=True, help="Path or glob to MAGs (e.g. asm/*/bins).")
-	parser.add_argument("--tmp", type=str, default="tmp", help="Temporary working directory.")
+	parser.add_argument("--tmpdir", type=str, default="tmp", help="Temporary working directory.")
 	parser.add_argument("--threads", type=int, default=4, help="Number of threads for canolax5.")
 	parser.add_argument("--extension", type=str, default="fa", help="File extension of MAGs (default: fa).")
 	parser.add_argument("-w", "--wildcard", type=str, default="", help="Pattern to match anywhere in MAG path.")
@@ -201,7 +201,7 @@ def main():
 
 	runner = Dereplicator(
 		args.mag_dir,
-		args.tmp,
+		args.tmpdir,
 		args.threads,
 		args.extension,
 		args.wildcard,

--- a/magus/finalize-bacterial-mags.py
+++ b/magus/finalize-bacterial-mags.py
@@ -4,13 +4,13 @@ import argparse
 import pandas as pd
 
 class FinalMAGMerge:
-    def __init__(self, tmp_dir,singleassembly_mag_dir, coasm_mag_dir, outdir, threads=28):
+    def __init__(self, tmpdir,singleassembly_mag_dir, coasm_mag_dir, outdir, threads=28):
         self.original_mag_dir = singleassembly_mag_dir
         self.new_coasm_dir = coasm_mag_dir
         self.outdir = outdir
         self.merged_output = outdir + '/magus_consolidated_bac_arc_mags.fasta'
         self.threads = threads
-        self.tmpdir = tmp_dir
+        self.tmpdir = tmpdir
         os.makedirs(self.tmpdir, exist_ok=True)
         os.makedirs(self.outdir, exist_ok=True)
 
@@ -93,7 +93,7 @@ def main():
     parser.add_argument('--coasm_mag_dir', type=str, default="coasm/mags", help='New co-assembled MAGs directory (default: coasm/mags)')
     parser.add_argument('--outdir', type=str, default="magus_output/magus_bacteria_archaea", help='Merged output file (default: magus_output/magus_bacteria_archaea/)')
     parser.add_argument('--threads', type=int, default=28, help='Number of threads (default: 28)')
-    parser.add_argument('--tmp_dir', default = 'tmp/finalize-bacterial-mags',type=str, help='Temporary directory (default: tmp/finalize-bacterial-mags)')
+    parser.add_argument('--tmpdir', default = 'tmp/finalize-bacterial-mags',type=str, help='Temporary directory (default: tmp/finalize-bacterial-mags)')
 
     args = parser.parse_args()
 
@@ -101,7 +101,7 @@ def main():
         singleassembly_mag_dir=args.singleassembly_mag_dir,
         coasm_mag_dir=args.coasm_mag_dir,
         outdir=args.outdir,
-        tmp_dir=args.tmp_dir,
+        tmpdir=args.tmpdir,
         threads=args.threads
     )
     final_merge.run()

--- a/magus/find-viruses.py
+++ b/magus/find-viruses.py
@@ -7,21 +7,21 @@ from pathlib import Path
 import csv
 
 class CheckVRunner:
-    def __init__(self, asm_paths, checkv_db, combined_contig_file, filtered_contig_file, min_length, max_length, threads, quality, tmp_dir="tmp/run_checkv", config_file=None):
+    def __init__(self, asm_paths, checkv_db, combined_contig_file, filtered_contig_file, min_length, max_length, threads, quality, tmpdir="tmp/run_checkv", config_file=None):
         self.asm_paths = asm_paths
-        self.combined_contig_file = os.path.join(tmp_dir, combined_contig_file)
-        self.filtered_contig_file = os.path.join(tmp_dir, filtered_contig_file)
+        self.combined_contig_file = os.path.join(tmpdir, combined_contig_file)
+        self.filtered_contig_file = os.path.join(tmpdir, filtered_contig_file)
         self.min_length = min_length
         self.max_length = max_length
         self.threads = threads
-        self.tmp_dir = tmp_dir
+        self.tmp_dir = tmpdir
         self.quality = set(quality)
         self.virus_dir = os.path.join("magus_viruses")
         self.checkv_db = checkv_db
         self.config_file = config_file
         self.contig_files = []
         os.makedirs(self.virus_dir, exist_ok=True)
-        os.makedirs(tmp_dir, exist_ok=True)
+        os.makedirs(tmpdir, exist_ok=True)
 
     def find_contig_files_from_config(self):
         """Find contig files from a config file similar to call_orfs.py."""
@@ -250,7 +250,7 @@ if __name__ == "__main__":
     parser.add_argument("--max_length", type=int, default=1000000000, help="Maximum length of contigs to include")
     parser.add_argument("--threads", type=int, default=28, help="Number of threads for CheckV")
     parser.add_argument("--quality", type=str, default="CHM", help="Viral contig levels to include (C [Complete], H [High], M [Medium], L [Low])")
-    parser.add_argument("--tmp_dir", type=str, default="tmp/run_checkv", help="Temporary directory for storing intermediate files")
+    parser.add_argument("--tmpdir", type=str, default="tmp/run_checkv", help="Temporary directory for storing intermediate files")
     parser.add_argument("--checkv_db", type=str, required=True, help="Path to the CheckV database directory")
     parser.add_argument(
         "--restart",
@@ -276,7 +276,7 @@ if __name__ == "__main__":
         max_length=args.max_length,
         threads=args.threads,
         quality=args.quality,
-        tmp_dir=args.tmp_dir,
+        tmpdir=args.tmpdir,
         config_file=config_file
     )
     # If restarting from cleanup, validate CheckV outputs exist and resume post-CheckV steps

--- a/magus/magus_main.py
+++ b/magus/magus_main.py
@@ -19,7 +19,7 @@ def main():
         'taxonomy': 'taxonomy.py',
         'cluster-contigs': 'cluster-contigs.py',
         'single-assembly': 'single-assembly.py',
-        'single-binning': 'single-binning.py',
+        'binning': 'single-binning.py',
         'cluster-contigs': 'cluster-contigs.py',
         'coassembly': 'coassembly.py',
         'coassembly-binning': 'coassembly-binning.py',

--- a/magus/single-binning.py
+++ b/magus/single-binning.py
@@ -6,13 +6,13 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import shutil
 
 class Binning:
-    def __init__(self, config, tmp_dir, asmdir, magdir="mags", threads=14, checkm_db=None,
+    def __init__(self, config, tmpdir, asmdir, magdir="mags", threads=14, checkm_db=None,
                  test_mode=False, max_workers=4, completeness=None,
                  contamination=None, quality=None, restart=None):
         self.config = self.load_config(config)
         self.asmdir = asmdir
         self.magdir = asmdir+"/"+magdir
-        self.tmpdir = tmp_dir
+        self.tmpdir = tmpdir
         self.threads = threads
         self.checkm_db = checkm_db  # Custom CheckM database path
         self.test_mode = test_mode  # Flag for test mode
@@ -324,7 +324,7 @@ def main():
     parser.add_argument('--checkm_db', type=str, default=None, help='Path to custom CheckM database')
     parser.add_argument('--asmdir', type=str, default="asm", help='Output directory for assembly (default: asm)')
     parser.add_argument('--max_workers', type=int, default=4, help='Maximum number of parallel workers (default: 4)')
-    parser.add_argument('--tmp_dir', type=str, default='tmp/single-binning', help='Temp directory. Default tmp/single-binning.')
+    parser.add_argument('--tmpdir', type=str, default='tmp/binning', help='Temp directory. Default tmp/binning.')
     parser.add_argument('--test_mode', action='store_true', help='Enable test mode with relaxed filtering criteria')
     parser.add_argument('--completeness', type=float, default=None, help='Completeness threshold for filtering bins')
     parser.add_argument('--contamination', type=float, default=None, help='Contamination threshold for filtering bins')
@@ -352,7 +352,7 @@ def main():
         threads=args.threads,
         checkm_db=args.checkm_db,
         asmdir=args.asmdir,
-        tmp_dir=args.tmp_dir,
+        tmpdir=args.tmpdir,
         max_workers=args.max_workers,
         test_mode=args.test_mode,
         completeness=args.completeness,


### PR DESCRIPTION
## Summary
- expand the README command catalogue to reflect the full `magus` CLI and refreshed option descriptions
- standardize temporary-directory arguments on `--tmpdir` across the pipeline scripts
- update helpers to pass the renamed option through their constructors
- rename the single-assembly binning CLI to `magus binning` and refresh associated documentation and defaults

## Testing
- python -m compileall magus

------
https://chatgpt.com/codex/tasks/task_e_68dfe09ca3c0832ebee57a53247172f6